### PR TITLE
Fix MacOS support: prevent killing cloudflared on non-fatal errors.

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -103,6 +103,9 @@ async function createTunnel(): Promise<void> {
           }
           progress.report({ message: "Starting tunnel..." });
           await cloudflared.startTunnel(tunnel);
+          tunnel.process?.on("exit", () => {
+            cloudflareTunnelProvider.removeTunnel(tunnel);
+          });
         }
       );
 

--- a/src/providers/tunnels.ts
+++ b/src/providers/tunnels.ts
@@ -27,6 +27,9 @@ export class CloudflareTunnelProvider
 
   removeTunnel(tunnel: CloudflareTunnel): void {
     const index = this.#tunnels.indexOf(tunnel);
+    if (index === -1) {
+      return;
+    }
     this.#tunnels.splice(index, 1);
     this.refresh();
   }


### PR DESCRIPTION
Fixes the bug when these errors cause the daemon to be closed by
the extension.

The process shouldn't be killed forcefully if
| ERR update check failed error="no release found"
or
| ERR  error="Unable to reach the origin service.
are met in cloudflared's output streams.

