### PR TITLE
MacOs: remove original archive file.

### DIFF
--- a/src/cmd/downloader.ts
+++ b/src/cmd/downloader.ts
@@ -43,6 +43,7 @@ export default class CloudflaredDownloader {
 
     // Renamed extracted "cloudflared" to fileName
     await fs.promises.rename(extractedFilePath, renamedFilePath);
+    await fs.promises.unlink(uri.fsPath);
 
     return vscode.Uri.file(renamedFilePath);
   }


### PR DESCRIPTION
After unpacking of the binary out of the archive,
there's no need to store the original downloaded file.